### PR TITLE
Add pipeline reuse for style generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Este proyecto es una aplicación web interactiva creada con Streamlit que permit
     - Permite clasificar la imagen generada en la columna 1.
     - Devuelve etiquetas con puntajes de confianza.
 
+- Estilización de Rostro (Columna 3):
+
+    - Aplica un modelo de estilo artístico a un rostro detectado.
+    - Genera un fondo con Stable Diffusion usando un prompt.
+    - Combina el rostro estilizado con el fondo resultante.
+
 Requisitos Previos
 - Python 3.9 o superior instalado.
 - Docker (opcional, si deseas ejecutar la aplicación dentro de un contenedor).

--- a/app.py
+++ b/app.py
@@ -256,7 +256,12 @@ elif opcion == "Estilización de Rostro para CV":
 
             if st.button("Generar imagen final"):
                 with st.spinner("Generando imagen final..."):
-                    imagen_final = aplicar_estilo_y_fondo(rostro, fondo_prompt, estilo_model_path=modelo_estilo_path)
+                    imagen_final = aplicar_estilo_y_fondo(
+                        rostro,
+                        fondo_prompt,
+                        estilo_model_path=modelo_estilo_path,
+                        pipe=generation_model,
+                    )
                 st.image(imagen_final, caption="Imagen final", use_container_width=True)
 
                 # Botón para descargar la imagen final


### PR DESCRIPTION
## Summary
- allow `aplicar_estilo_y_fondo` to reuse an existing diffusion pipeline
- pass the shared pipeline from `app.py`
- document new feature and update README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685225bf9c508321a35c6d44debe52d6